### PR TITLE
libocheck: use inttypes.h pointer-width uint type

### DIFF
--- a/lib/allocs.c
+++ b/lib/allocs.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <errno.h>
 
-#include "frame_size.h"
 #include "backtraces.h"
 #include "ocheck.h"
 #include "ocheck-internal.h"
@@ -76,9 +75,9 @@ static void initialize()
 
 #define END_CALL(ptr, size) \
 	if (lib_inited) {\
-		uint_ptr_size_t frames[BACK_FRAMES_COUNT] = {0}; \
+		uintptr_t frames[BACK_FRAMES_COUNT] = {0}; \
 		backtraces(frames, ARRAY_SIZE(frames)); \
-		store_message(ALLOC, (uint_ptr_size_t)ptr, size, frames); \
+		store_message(ALLOC, (uintptr_t)ptr, size, frames); \
 	}
 
 void* malloc(size_t size)
@@ -105,7 +104,7 @@ void* realloc(void *ptr, size_t size)
 	START_CALL();
 	out_ptr = real_realloc(ptr, size);
 	if (ptr != out_ptr)
-		remove_message(ALLOC, (uint_ptr_size_t)ptr);
+		remove_message(ALLOC, (uintptr_t)ptr);
 	END_CALL(out_ptr, size);
 	return out_ptr;
 }
@@ -115,7 +114,7 @@ void free(void *ptr)
 	START_CALL();
 	real_free(ptr);
 	if (ptr)
-		remove_message(ALLOC, (uint_ptr_size_t)ptr);
+		remove_message(ALLOC, (uintptr_t)ptr);
 }
 
 void* memalign(size_t blocksize, size_t bytes)

--- a/lib/backtraces.c
+++ b/lib/backtraces.c
@@ -1,5 +1,4 @@
 
-#include "frame_size.h"
 #include "backtraces.h"
 
 #ifndef ARRAY_SIZE
@@ -16,7 +15,7 @@ void backtraces_set_max_backtraces(uint32_t max_backtraces)
    But gcc docs says that this is arch dependant, so this should be called in the
    main() function with 'ocheck_guard_frame = (uint32_t) __builtin_return_address(0);'.
 */
-uint_ptr_size_t ocheck_guard_frame = 0;
+uintptr_t ocheck_guard_frame = 0;
 
 enum BT_RESULT {
     BT_DONE,
@@ -30,9 +29,9 @@ enum BT_RESULT {
 */
 
 #define backtraces_(N) \
-	static enum BT_RESULT backtraces_##N(uint_ptr_size_t *frames) \
+	static enum BT_RESULT backtraces_##N(uintptr_t *frames) \
 	{ \
-		frames[N] = (uint_ptr_size_t) __builtin_return_address(N); \
+		frames[N] = (uintptr_t) __builtin_return_address(N); \
 		return (frames[N] != ocheck_guard_frame) ? BT_HAVE_MORE : BT_DONE; \
 	}
 
@@ -53,7 +52,7 @@ backtraces_(13);
 backtraces_(14);
 backtraces_(15);
 
-typedef enum BT_RESULT (*backtraces_func)(uint_ptr_size_t *);
+typedef enum BT_RESULT (*backtraces_func)(uintptr_t *);
 
 static backtraces_func backtraces_funcs[] = {
 	backtraces_0,
@@ -76,7 +75,7 @@ static backtraces_func backtraces_funcs[] = {
 };
 
 /* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=8743 */
-void backtraces(uint_ptr_size_t *frames, uint32_t max_frames)
+void backtraces(uintptr_t *frames, uint32_t max_frames)
 {
 	int i, res = BT_HAVE_MORE;
 	for (i = 0; i < g_max_backtraces && i < max_frames && backtraces_funcs[i] && res == BT_HAVE_MORE; i++)

--- a/lib/backtraces.h
+++ b/lib/backtraces.h
@@ -2,9 +2,9 @@
 
 #include <stdint.h>
 
-void backtraces(uint_ptr_size_t *frames, uint32_t max_frames);
+void backtraces(uintptr_t *frames, uint32_t max_frames);
 void backtraces_set_max_backtraces(uint32_t max_backtraces);
 
-extern uint_ptr_size_t ocheck_guard_frame;
+extern uintptr_t ocheck_guard_frame;
 
 #endif

--- a/lib/frame_size.h
+++ b/lib/frame_size.h
@@ -5,7 +5,7 @@
 #if __GNUC__
 #if __x86_64__ || __ppc64__
 #define uint_ptr_size_t	uint64_t
-#define PRIxPTR1	"0x%16lx"
+#define PRIxPTR1	"0x%016lx"
 #else
 #define uint_ptr_size_t	uint32_t
 #define PRIxPTR1	"0x%08x"

--- a/lib/frame_size.h
+++ b/lib/frame_size.h
@@ -1,15 +1,11 @@
 #ifndef __FRAME_SIZE_H__
 
-#include <stdint.h>
+#include <inttypes.h>
 
-#if __GNUC__
-#if __x86_64__ || __ppc64__
-#define uint_ptr_size_t	uint64_t
-#define PRIxPTR1	"0x%016lx"
+#if UINTPTR_MAX > 0xFFFFFFFF
+#define PRIxPTR_PAD	"016" PRIxPTR
 #else
-#define uint_ptr_size_t	uint32_t
-#define PRIxPTR1	"0x%08x"
-#endif
+#define PRIxPTR_PAD	"08" PRIxPTR
 #endif
 
 #endif

--- a/lib/ocheck-internal.h
+++ b/lib/ocheck-internal.h
@@ -5,7 +5,7 @@
 
 extern bool lib_inited;
 
-void store_message(enum msg_type type, uint_ptr_size_t id, size_t size, uint_ptr_size_t *frames);
+void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *frames);
 void remove_message(enum msg_type type, uint32_t id);
 
 #define debug(...) { \

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -12,7 +12,6 @@
 #include <errno.h>
 #include <string.h>
 
-#include "frame_size.h"
 #include "backtraces.h"
 #include "ocheck.h"
 #include "ocheck-internal.h"
@@ -160,7 +159,7 @@ static inline struct call_msg *call_msg_get_free()
 	return NULL;
 }
 
-void store_message(enum msg_type type, uint_ptr_size_t id, size_t size, uint_ptr_size_t *frames)
+void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *frames)
 {
 	struct call_msg *msg;
 

--- a/lib/ocheck.h
+++ b/lib/ocheck.h
@@ -35,9 +35,9 @@ struct proc_msg {
 struct call_msg {
 	uint32_t magic;
 	uint16_t type;
-	uint_ptr_size_t id; /* Could be ptr, fd, some other ID */
+	uintptr_t id; /* Could be ptr, fd, some other ID */
 	uint16_t tid;
-	uint_ptr_size_t frames[BACK_FRAMES_COUNT];
+	uintptr_t frames[BACK_FRAMES_COUNT];
 	uint32_t size;
 } __attribute__((__packed__));
 

--- a/ocheckd.c
+++ b/ocheckd.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <ctype.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -88,7 +89,7 @@ static void ocheckd_populate_list(struct list_head *lst, const char *name)
 	void *a = blobmsg_open_array(&b, name);
 
 #define blobmsg_add_hex_string(b, k, v) \
-	snprintf(buf, sizeof(buf), PRIxPTR1, v); \
+	snprintf(buf, sizeof(buf), "0x%"PRIxPTR_PAD, v); \
 	blobmsg_add_string(b, k, buf);
 
 	list_for_each_entry_safe(call, tmp, lst, list) {
@@ -219,7 +220,7 @@ static void call_add(struct ocheck_client *cl, struct call_msg *msg)
 	/* Sanity */
 	struct call *call = call_find(&cl->calls, msg->id);
 	if (call) {
-		log(LOG_WARNING, "Duplicate memory entry found (%u)("PRIxPTR1")'\n", msg->tid, msg->id);
+		log(LOG_WARNING, "Duplicate memory entry found (%u)(0x%"PRIxPTR_PAD")'\n", msg->tid, msg->id);
 		memcpy(&call->msg, msg, sizeof(call->msg));
 		return;
 	}


### PR DESCRIPTION
The checks in frame-size.h fail on PPC64, resulting in an incorrectly
sized definition for uint_ptr_size_t. Replacing it with the standard
uintptr_t is cleaner and also fixes this issue.

Signed-off-by: Florian Larysch <florian.larysch@riverbed.com>