### PR TITLE
ocheck: Add hooks on file management API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ ocheckd_OBJS:= \
 libocheck_OBJS:= \
 	lib/ocheck.o \
 	lib/backtraces.o \
-	lib/allocs.o
+	lib/allocs.o \
+	lib/file.o
 
 libocheck.so: $(libocheck_OBJS)
 	$(CC) -shared $(LDFLAGS) $(CFLAGS) -o $@ $^ -ldl

--- a/lib/allocs.c
+++ b/lib/allocs.c
@@ -71,14 +71,10 @@ static void initialize()
 }
 
 #define START_CALL() \
-	initialize(); \
+	initialize();
 
-#define END_CALL(ptr, size) \
-	if (lib_inited) {\
-		uintptr_t frames[BACK_FRAMES_COUNT] = {0}; \
-		backtraces(frames, ARRAY_SIZE(frames)); \
-		store_message(ALLOC, (uintptr_t)ptr, size, frames); \
-	}
+#define END_CALL(ptr,size) \
+	PUSH_MSG(ALLOC, ptr, size)
 
 void* malloc(size_t size)
 {

--- a/lib/file.c
+++ b/lib/file.c
@@ -1,0 +1,82 @@
+#include <dlfcn.h>
+#include "ocheck.h"
+#include "ocheck-internal.h"
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static FILE* (*real_fopen)(const char*, const char*);
+static int (*real_fclose)(FILE*);
+static int (*real_open)(const char *filename, int flags, ...);
+static int (*real_close)(int fd);
+
+static void initialize()
+{
+	static bool initialized = false;
+
+	if (initialized) {
+		return;
+	}
+
+	real_fopen = dlsym(RTLD_NEXT, "fopen");
+	real_fclose = dlsym(RTLD_NEXT, "fclose");
+	real_open = dlsym(RTLD_NEXT, "open");
+	real_close = dlsym(RTLD_NEXT, "close");
+
+	if ((real_fopen == NULL) || (real_fclose == NULL)
+		|| (real_open == NULL) || (real_close == NULL)) {
+		debug_exit("Error in `dlsym`: %s\n", dlerror());
+	}
+
+	initialized = true;
+}
+
+#define START_CALL() \
+	initialize();
+
+#define END_CALL(fd) \
+	PUSH_MSG(FILES, fd, 0)
+
+FILE* fopen(const char* filename, const char* mode)
+{
+	FILE* fd = NULL;
+	START_CALL();
+	fd = real_fopen(filename, mode);
+	END_CALL(fd);
+	return fd;
+}
+
+int fclose(FILE* fd)
+{
+	int result = EOF;
+	START_CALL();
+	if (fd != NULL) {
+		result = real_fclose(fd);
+		remove_message(FILES, (uintptr_t)fd);
+	}
+	return result;
+}
+
+int open(const char *filename, int flags, ...)
+{
+	int fd = -1;
+	START_CALL();
+	va_list args;
+	va_start(args, flags);
+	fd = real_open(filename, flags, args);
+	va_end(args);
+	END_CALL(fd);
+	return fd;
+}
+
+int close(int fd)
+{
+	int result = -1;
+	START_CALL();
+	if (fd >= 0) {
+		result = real_close(fd);
+		remove_message(FILES, (uintptr_t)fd);
+	}
+	return result;
+}

--- a/lib/ocheck-internal.h
+++ b/lib/ocheck-internal.h
@@ -2,9 +2,12 @@
 #define __OCHECK_INTERNAL_H__
 
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 
 extern bool lib_inited;
 
+void backtraces(uintptr_t *frames, uint32_t max_frames);
 void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *frames);
 void remove_message(enum msg_type type, uint32_t id);
 
@@ -22,5 +25,12 @@ void remove_message(enum msg_type type, uint32_t id);
 	debug(__VA_ARGS__); \
 	exit(1); \
 }
+
+#define PUSH_MSG(type, ptr, size) \
+	if (lib_inited) {\
+		uintptr_t frames[BACK_FRAMES_COUNT] = {0}; \
+		backtraces(frames, ARRAY_SIZE(frames)); \
+		store_message(type, (uintptr_t)ptr, size, frames); \
+	}
 
 #endif

--- a/lib/ocheck.h
+++ b/lib/ocheck.h
@@ -18,6 +18,7 @@
 enum msg_type {
 	PROC_NAME = 1,
 	ALLOC,
+	FILES,
 	CLEAR,
 };
 

--- a/ocheckd.c
+++ b/ocheckd.c
@@ -81,7 +81,9 @@ static void ocheckd_connect_handler(struct ubus_context *ctx)
 	ubus_add_object(ctx, &ocheckd_object);
 }
 
-static void ocheckd_populate_list(struct list_head *lst, const char *name)
+static void ocheckd_populate_list(struct list_head *lst,
+	const char *name,
+	enum msg_type type)
 {
 	struct call *call, *tmp;
 	uint32_t call_count = 0;
@@ -93,9 +95,13 @@ static void ocheckd_populate_list(struct list_head *lst, const char *name)
 	blobmsg_add_string(b, k, buf);
 
 	list_for_each_entry_safe(call, tmp, lst, list) {
+		struct call_msg *m = &call->msg;
+
+		if (m->type != type)
+			continue;
+
 		int i;
 		void *t = blobmsg_open_table(&b, "");
-		struct call_msg *m = &call->msg;
 
 		blobmsg_add_u32(&b, "tid", m->tid);
 		blobmsg_add_hex_string(&b, "ptr", m->id);
@@ -126,7 +132,7 @@ static int ocheckd_list_handler(struct ubus_context *ctx,
 
 	list_for_each_entry_safe(cl, tmp, &ocheck_client_list, list) {
 		void *p = blobmsg_open_table(&b, cl->proc);
-		ocheckd_populate_list(&cl->calls, "allocs");
+		ocheckd_populate_list(&cl->calls, "allocs", ALLOC);
 		blobmsg_close_table(&b, p);
 	}
 
@@ -200,7 +206,7 @@ static inline void __create_call_to_list(struct list_head *lst, struct call_msg 
 	list_add(&call->list, lst);
 }
 
-static inline struct call *call_find(struct list_head *lst, uint32_t id)
+static inline struct call *call_find(struct list_head *lst, struct call_msg *msg)
 {
 	struct call *call, *tmp;
 
@@ -209,7 +215,7 @@ static inline struct call *call_find(struct list_head *lst, uint32_t id)
 
 	list_for_each_entry_safe(call, tmp, lst, list) {
 		struct call_msg *m = &call->msg;
-		if (m->id == id)
+		if ((m->id == msg->id) && (m->type == msg->type))
 			return call;
 	}
 	return NULL;
@@ -218,7 +224,7 @@ static inline struct call *call_find(struct list_head *lst, uint32_t id)
 static void call_add(struct ocheck_client *cl, struct call_msg *msg)
 {
 	/* Sanity */
-	struct call *call = call_find(&cl->calls, msg->id);
+	struct call *call = call_find(&cl->calls, msg);
 	if (call) {
 		log(LOG_WARNING, "Duplicate memory entry found (%u)(0x%"PRIxPTR_PAD")'\n", msg->tid, msg->id);
 		memcpy(&call->msg, msg, sizeof(call->msg));

--- a/ocheckd.c
+++ b/ocheckd.c
@@ -133,6 +133,7 @@ static int ocheckd_list_handler(struct ubus_context *ctx,
 	list_for_each_entry_safe(cl, tmp, &ocheck_client_list, list) {
 		void *p = blobmsg_open_table(&b, cl->proc);
 		ocheckd_populate_list(&cl->calls, "allocs", ALLOC);
+		ocheckd_populate_list(&cl->calls, "files", FILES);
 		blobmsg_close_table(&b, p);
 	}
 
@@ -292,6 +293,7 @@ static void client_cb(struct uloop_fd *u, unsigned int events)
 			case PROC_NAME:
 				r = handle_proc_name_msg(cl, msg_pos);
 				break;
+			case FILES:
 			case ALLOC:
 				r = handle_call_msg(cl, msg_pos);
 				break;


### PR DESCRIPTION
Decorate the fopen/fclose and open/close functions in order to track
the file operations. In addition, fixes the display of  32 bits
addresses.