### PR TITLE
ocheck: add a few new features

### DIFF
--- a/lib/allocs.c
+++ b/lib/allocs.c
@@ -74,7 +74,7 @@ static void initialize()
 	initialize();
 
 #define END_CALL(ptr,size) \
-	PUSH_MSG(ALLOC, ptr, size)
+	PUSH_MSG(ALLOC, ptr, -1, size)
 
 void* malloc(size_t size)
 {
@@ -100,7 +100,7 @@ void* realloc(void *ptr, size_t size)
 	START_CALL();
 	out_ptr = real_realloc(ptr, size);
 	if (ptr != out_ptr)
-		remove_message(ALLOC, (uintptr_t)ptr);
+		remove_message_by_ptr(ALLOC, (uintptr_t)ptr);
 	END_CALL(out_ptr, size);
 	return out_ptr;
 }
@@ -109,7 +109,7 @@ void free(void *ptr)
 {
 	START_CALL();
 	real_free(ptr);
-	remove_message(ALLOC, (uintptr_t)ptr);
+	remove_message_by_ptr(ALLOC, (uintptr_t)ptr);
 }
 
 void* memalign(size_t blocksize, size_t bytes)

--- a/lib/backtraces.h
+++ b/lib/backtraces.h
@@ -1,9 +1,11 @@
 #ifndef __BACKTRACES_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 
-void backtraces(uintptr_t *frames, uint32_t max_frames);
+bool backtraces(uintptr_t *frames, uint32_t max_frames);
 void backtraces_set_max_backtraces(uint32_t max_backtraces);
+void ignore_backtrace_push(uintptr_t frame, uint32_t range);
 
 extern uintptr_t ocheck_guard_frame;
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -35,15 +35,15 @@ static void initialize()
 #define START_CALL() \
 	initialize();
 
-#define END_CALL(fd) \
-	PUSH_MSG(FILES, fd, 0)
+#define END_CALL(ptr, fd) \
+	PUSH_MSG(FILES, ptr, fd, 0)
 
 FILE* fopen(const char* filename, const char* mode)
 {
 	FILE* fd = NULL;
 	START_CALL();
 	fd = real_fopen(filename, mode);
-	END_CALL(fd);
+	END_CALL(fd, -1);
 	return fd;
 }
 
@@ -52,7 +52,7 @@ int fclose(FILE* fd)
 	int result = EOF;
 	START_CALL();
 	result = real_fclose(fd);
-	remove_message(FILES, (uintptr_t)fd);
+	remove_message_by_ptr(FILES, (uintptr_t)fd);
 	return result;
 }
 
@@ -64,7 +64,7 @@ int open(const char *filename, int flags, ...)
 	va_start(args, flags);
 	fd = real_open(filename, flags, args);
 	va_end(args);
-	END_CALL(fd);
+	END_CALL(NULL, fd);
 	return fd;
 }
 
@@ -73,6 +73,6 @@ int close(int fd)
 	int result = -1;
 	START_CALL();
 	result = real_close(fd);
-	remove_message(FILES, fd);
+	remove_message_by_fd(FILES, fd);
 	return result;
 }

--- a/lib/ocheck-internal.h
+++ b/lib/ocheck-internal.h
@@ -8,8 +8,9 @@
 
 extern bool lib_inited;
 
-void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *frames);
-void remove_message(enum msg_type type, uint32_t id);
+void store_message(enum msg_type type, uintptr_t ptr, int fd, size_t size, uintptr_t *frames);
+void remove_message_by_ptr(enum msg_type type, uintptr_t ptr);
+void remove_message_by_fd(enum msg_type type, int fd);
 
 #define debug(...) { \
 	FILE *fp = fopen("/tmp/ocheck.out", "ab"); \
@@ -26,11 +27,11 @@ void remove_message(enum msg_type type, uint32_t id);
 	exit(1); \
 }
 
-#define PUSH_MSG(type, ptr, size) \
+#define PUSH_MSG(type, ptr, fd, size) \
 	if (lib_inited) {\
 		uintptr_t frames[BACK_FRAMES_COUNT] = {0}; \
 		if (backtraces(frames, ARRAY_SIZE(frames))) \
-			store_message(type, (uintptr_t)ptr, size, frames); \
+			store_message(type, (uintptr_t)ptr, fd, size, frames); \
 	}
 
 #endif

--- a/lib/ocheck-internal.h
+++ b/lib/ocheck-internal.h
@@ -11,6 +11,7 @@ extern bool lib_inited;
 void store_message(enum msg_type type, uintptr_t ptr, int fd, size_t size, uintptr_t *frames);
 void remove_message_by_ptr(enum msg_type type, uintptr_t ptr);
 void remove_message_by_fd(enum msg_type type, int fd);
+void update_message_ptr_by_fd(enum msg_type type, uintptr_t ptr, int fd);
 
 #define debug(...) { \
 	FILE *fp = fopen("/tmp/ocheck.out", "ab"); \

--- a/lib/ocheck-internal.h
+++ b/lib/ocheck-internal.h
@@ -4,10 +4,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "backtraces.h"
 
 extern bool lib_inited;
 
-void backtraces(uintptr_t *frames, uint32_t max_frames);
 void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *frames);
 void remove_message(enum msg_type type, uint32_t id);
 
@@ -29,8 +29,8 @@ void remove_message(enum msg_type type, uint32_t id);
 #define PUSH_MSG(type, ptr, size) \
 	if (lib_inited) {\
 		uintptr_t frames[BACK_FRAMES_COUNT] = {0}; \
-		backtraces(frames, ARRAY_SIZE(frames)); \
-		store_message(type, (uintptr_t)ptr, size, frames); \
+		if (backtraces(frames, ARRAY_SIZE(frames))) \
+			store_message(type, (uintptr_t)ptr, size, frames); \
 	}
 
 #endif

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -132,7 +132,7 @@ static uint32_t flush_messages(bool now)
 
 	for (i = 0; i < ARRAY_SIZE(messages) && curr_flush_state == BUSY; i++) {
 		struct call_msg *msg = &messages[i];
-		if (!msg->id) /* For now we consider non-zero IDs as valid IDs ; this could change */
+		if (!msg->ptr && msg->fd < 0)
 			continue;
 		if (write_retry(fd, (uint8_t *) msg, sizeof(*msg)) < 0)
 			debug_exit("Could not send message ; errno %d\n", errno);
@@ -143,13 +143,46 @@ static uint32_t flush_messages(bool now)
 	return flushed;
 }
 
-static inline struct call_msg *call_msg_find(enum msg_type type, uint32_t id)
+static inline void call_msg_invalidate(struct call_msg *msg)
+{
+	if (msg) {
+		msg->type = INVALID;
+		msg->ptr = 0;
+		msg->fd = -1;
+	}
+}
+
+static struct call_msg *call_msg_find_by_ptr(enum msg_type type, uintptr_t ptr)
 {
 	int i;
-	if (!id)
+	if (!ptr)
 		return NULL;
 	for (i = 0; i < ARRAY_SIZE(messages); i++) {
-		if (messages[i].type == type && messages[i].id == id)
+		if (messages[i].type == type && messages[i].ptr == ptr)
+			return &messages[i];
+	}
+	return NULL;
+}
+
+static struct call_msg *call_msg_find_by_fd(enum msg_type type, int fd)
+{
+	int i;
+	if (fd < 0)
+		return NULL;
+	for (i = 0; i < ARRAY_SIZE(messages); i++) {
+		if (messages[i].type == type && messages[i].fd == fd)
+			return &messages[i];
+	}
+	return NULL;
+}
+
+static inline struct call_msg *call_msg_find(enum msg_type type, uintptr_t ptr, int fd)
+{
+	int i;
+	for (i = 0; i < ARRAY_SIZE(messages); i++) {
+		if (messages[i].type != type)
+			continue;
+		if (messages[i].ptr == ptr && messages[i].fd == fd)
 			return &messages[i];
 	}
 	return NULL;
@@ -159,22 +192,21 @@ static inline struct call_msg *call_msg_get_free()
 {
 	int i;
 	for (i = 0; i < ARRAY_SIZE(messages); i++) {
-		/* For now we consider non-zero IDs as valid IDs ; this could change */
-		if (!messages[i].id)
+		if (messages[i].type == INVALID)
 			return &messages[i];
 	}
 	return NULL;
 }
 
-void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *frames)
+void store_message(enum msg_type type, uintptr_t ptr, int fd, size_t size, uintptr_t *frames)
 {
 	struct call_msg *msg;
 
-	/* FIXME: see what we do in this case ; this looks like a malfunction ; for now we ignore */
-	if ((msg = call_msg_find(type, id)))
-		msg->id = 0;
+	if (fd < 0 && !ptr)
+		return;
 
-	if (!msg) {
+	/* FIXME: see what we do in this case ; this looks like a malfunction ; for now we ignore */
+	if (!(msg = call_msg_find(type, ptr, fd))) {
 		msg = call_msg_get_free();
 		if (!msg)
 			debug_exit("No more room to store calls\n");
@@ -183,7 +215,8 @@ void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *fra
 	msg->magic = MSG_MAGIC_NUMBER;
 	msg->type  = type;
 	msg->tid   = ourgettid();
-	msg->id    = id;
+	msg->ptr   = ptr;
+	msg->fd    = fd;
 	msg->size  = size; 
 	memcpy(msg->frames, frames, sizeof(msg->frames));
 
@@ -193,14 +226,14 @@ void store_message(enum msg_type type, uintptr_t id, size_t size, uintptr_t *fra
 	flush_messages(false);
 }
 
-void remove_message(enum msg_type type, uint32_t id)
+void remove_message_by_ptr(enum msg_type type, uintptr_t ptr)
 {
-	struct call_msg *msg;
-	/* FIXME: this can be an invalid call/free ; store later */
-	if ((msg = call_msg_find(type, id))) {
-		msg->type = INVALID;
-		msg->id = 0;
-	}
+	call_msg_invalidate(call_msg_find_by_ptr(type, ptr));
+}
+
+void remove_message_by_fd(enum msg_type type, int fd)
+{
+	call_msg_invalidate(call_msg_find_by_fd(type, fd));
 }
 
 static const char *progname(int pid)
@@ -310,6 +343,7 @@ static __attribute__((constructor(101))) void ocheck_init()
 	struct proc_msg msg;
 	const char *proc_name;
 	const char *s;
+	int i;
 
 	/* Do not re-initialize if already initialized and it's the same pid */
 	if (lib_inited && (pid == ourgetpid()))
@@ -332,6 +366,10 @@ static __attribute__((constructor(101))) void ocheck_init()
 	/* if max_flush_counter <= 0 then flush only on ocheck_fini() */
 	if ((s = getenv("FLUSH_COUNT")))
 		max_flush_counter = atoi(s);
+
+	/* Initialize fd to negative */
+	for (i = 0; i < ARRAY_SIZE(messages); i++)
+		messages[i].fd = -1;
 
 	/* We won't get here, since initialize_sock() calls exit(1) in case something does not init  */
 	msg.magic = MSG_MAGIC_NUMBER;

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -236,6 +236,15 @@ void remove_message_by_fd(enum msg_type type, int fd)
 	call_msg_invalidate(call_msg_find_by_fd(type, fd));
 }
 
+void update_message_ptr_by_fd(enum msg_type type, uintptr_t ptr, int fd)
+{
+	struct call_msg *msg;
+	if (fd < 0)
+		return;
+	if ((msg = call_msg_find_by_fd(type, fd)))
+		msg->ptr = ptr;
+}
+
 static const char *progname(int pid)
 {
 	FILE *proc;

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -19,7 +19,7 @@
 #define DEFAULT_MAX_FLUSH_COUNTER	512
 static uint32_t max_flush_counter = DEFAULT_MAX_FLUSH_COUNTER;
 static int fd = -1;
-static struct call_msg messages[32 * 1024] = {0};
+static struct call_msg messages[512 * 1024] = {0};
 static int flush_counter = -1;
 static pid_t pid = -1;
 

--- a/lib/ocheck.h
+++ b/lib/ocheck.h
@@ -37,7 +37,8 @@ struct proc_msg {
 struct call_msg {
 	uint32_t magic;
 	uint16_t type;
-	uintptr_t id; /* Could be ptr, fd, some other ID */
+	uintptr_t ptr;
+	int fd;
 	uint16_t tid;
 	uintptr_t frames[BACK_FRAMES_COUNT];
 	uint32_t size;

--- a/ocheckd.c
+++ b/ocheckd.c
@@ -106,7 +106,8 @@ static void ocheckd_populate_list(struct list_head *lst,
 		void *t = blobmsg_open_table(&b, "");
 
 		blobmsg_add_u32(&b, "tid", m->tid);
-		blobmsg_add_hex_string(&b, "ptr", m->id);
+		blobmsg_add_hex_string(&b, "ptr", m->ptr);
+		blobmsg_add_u32(&b, "fd", m->fd);
 		for (i = 0; i < BACK_FRAMES_COUNT && m->frames[i]; i++) {
 			char frame_name[sizeof("frameX") + 1];
 			snprintf(frame_name, sizeof(frame_name), "frame%d", i);
@@ -219,7 +220,7 @@ static inline struct call *call_find(struct list_head *lst, struct call_msg *msg
 
 	list_for_each_entry_safe(call, tmp, lst, list) {
 		struct call_msg *m = &call->msg;
-		if ((m->id == msg->id) && (m->type == msg->type))
+		if ((m->ptr == msg->ptr) && (m->fd == msg->fd) && (m->type == msg->type))
 			return call;
 	}
 	return NULL;
@@ -230,7 +231,7 @@ static void call_add(struct ocheck_client *cl, struct call_msg *msg)
 	/* Sanity */
 	struct call *call = call_find(&cl->calls, msg);
 	if (call) {
-		log(LOG_WARNING, "Duplicate memory entry found (%u)(0x%"PRIxPTR_PAD")'\n", msg->tid, msg->id);
+		log(LOG_WARNING, "Duplicate memory entry found (%u)(0x%"PRIxPTR_PAD")(%d)'\n", msg->tid, msg->ptr, msg->fd);
 		memcpy(&call->msg, msg, sizeof(call->msg));
 		return;
 	}


### PR DESCRIPTION
Features:
* ability to ignore certain functions from backtraces via a `IGNORE_BT` env var; e.g.  `IGNORE_BT=func1:300,func2:400` ; where `func1` is an exported function/symbol and 300 is an arbitrary offset where allocation is being done
* bump number of messages to 512k ; after trying out the lib with libcurl, 32k wasn't enough anymore
* handle `socket()` call
* add `fdopen()` support ; technically once you call `fdopen()` the FD should be closed via `fclose()` to properly clean it up ; so in the ocheck case, we're just not tracking the FD anymore ; 
 * this may mean we'd need to add other libc functions (like fdopen()), but they'll get added as we find cases for them

Notes:
* removed `fopen()` and `fclose()` ; seems they do memory allocation ; so, it's a bit redundant to track them here too