### PR TITLE
ocheck: optimizations & cleanup

### DIFF
--- a/lib/allocs.c
+++ b/lib/allocs.c
@@ -70,9 +70,10 @@ void* realloc(void *ptr, size_t size)
 	void *out_ptr;
 	START_CALL();
 	out_ptr = real_realloc(ptr, size);
-	if (ptr != out_ptr)
+	if (ptr != out_ptr) {
 		remove_message_by_ptr(ALLOC, (uintptr_t)ptr);
-	END_CALL(out_ptr, size);
+		END_CALL(out_ptr, size);
+	}
 	return out_ptr;
 }
 

--- a/lib/allocs.c
+++ b/lib/allocs.c
@@ -10,43 +10,14 @@
 #include "ocheck.h"
 #include "ocheck-internal.h"
 
-static uint32_t heap_pos = 0;
-static uint8_t static_heap[256 * 1024];
-
-static void* init_malloc(size_t size)
-{
-	void *ptr;
-	if (heap_pos + size >= sizeof(static_heap))
-		exit(1);
-	ptr = &static_heap[heap_pos];
-	heap_pos += size;
-	return ptr;
-}
-
-static void* init_realloc(void *ptr, size_t size)
-{
-	return init_malloc(size);
-}
-
-static void* init_calloc(size_t nmemb, size_t size)
-{
-	void *ptr = init_malloc(nmemb * size);
-	unsigned int i = 0;
-	for (; i < nmemb * size; ++i)
-		*((uint8_t*)(ptr + i)) = '\0';
-	return ptr;
-}
-
-static void init_free(void *ptr) {}
-
-static void* (*real_malloc)(size_t size) = init_malloc;
-static void* (*real_calloc)(size_t nmemb, size_t size) = init_calloc;
-static void* (*real_realloc)(void *ptr, size_t size) = init_realloc;
-static void* (*real_memalign)(size_t blocksize, size_t bytes) = NULL;
-static void* (*real_valloc)(size_t size) = NULL;
+static void* (*real_malloc)(size_t size);
+static void* (*real_calloc)(size_t nmemb, size_t size);
+static void* (*real_realloc)(void *ptr, size_t size);
+static void* (*real_memalign)(size_t blocksize, size_t bytes);
+static void* (*real_valloc)(size_t size);
 static int   (*real_posix_memalign)(void** memptr, size_t alignment,
-                                     size_t size) = NULL;
-static void  (*real_free)(void *ptr) = init_free;
+                                     size_t size);
+static void  (*real_free)(void *ptr);
 
 static void initialize()
 {

--- a/ocheckd.c
+++ b/ocheckd.c
@@ -293,7 +293,7 @@ static void client_cb(struct uloop_fd *u, unsigned int events)
 	while ((r = read(u->fd, &cl->buf[cl->len], sizeof(cl->buf) - cl->len)) > 0)
 		cl->len += r;
 
-	while (cl->len > 0) {
+	while (cl->len >= sizeof(struct msg_common)) {
 		msg = (struct msg_common *)&cl->buf[msg_pos];
 
 		switch (msg->type) {
@@ -324,6 +324,8 @@ static void client_cb(struct uloop_fd *u, unsigned int events)
 		cl->len -= r;
 	}
 
+	if (cl->len > 0)
+		return;
 out:
 	ocheck_client_delete_empty(cl);
 }

--- a/ocheckd.c
+++ b/ocheckd.c
@@ -172,6 +172,9 @@ static void ocheck_client_list_clear(const char *name)
 			continue;
 		list_del(&cl->list);
 		ocheck_client_calls_clear_list(cl);
+		uloop_fd_delete(&cl->sock);
+		if (cl->sock.fd > -1)
+			close(cl->sock.fd);
 		free(cl);
 	}
 }


### PR DESCRIPTION
Optimization:
* buffer messages that are sent to ocheckd ; previously a lot of small writes were being done

Cleanup:
* don't use initial alloc + free functions ; the init function will already have initialized the functions to  the real alloc funcs

Misc:
* ocheckd: print `total` number of mem + fd leaks