### PR TITLE
ocheck: optimizations & cleanup (part 2)

### DIFF
--- a/lib/ocheck-internal.h
+++ b/lib/ocheck-internal.h
@@ -8,10 +8,21 @@
 
 extern bool lib_inited;
 
-void store_message(enum msg_type type, uintptr_t ptr, int fd, size_t size, uintptr_t *frames);
-void remove_message_by_ptr(enum msg_type type, uintptr_t ptr);
-void remove_message_by_fd(enum msg_type type, int fd);
-void update_message_ptr_by_fd(enum msg_type type, uintptr_t ptr, int fd);
+struct call_msg_store {
+	enum msg_type type;
+	uint32_t upper_index_limit;
+	uint32_t messages_count;
+	struct call_msg messages[];
+};
+
+void store_message_by_ptr(struct call_msg_store *store, uintptr_t ptr, size_t size, uintptr_t *frames);
+void store_message_by_fd(struct call_msg_store *store, int fd, uintptr_t *frames);
+void remove_message_by_ptr(struct call_msg_store *store, uintptr_t ptr);
+void remove_message_by_fd(struct call_msg_store *store, int fd);
+void update_message_ptr_by_fd(struct call_msg_store *store, uintptr_t ptr, int fd);
+
+struct call_msg_store *get_alloc_msg_store();
+struct call_msg_store *get_files_msg_store();
 
 #define debug(...) { \
 	FILE *fp = fopen("/tmp/ocheck.out", "ab"); \
@@ -27,12 +38,5 @@ void update_message_ptr_by_fd(enum msg_type type, uintptr_t ptr, int fd);
 	debug(__VA_ARGS__); \
 	exit(1); \
 }
-
-#define PUSH_MSG(type, ptr, fd, size) \
-	if (lib_inited) {\
-		uintptr_t frames[BACK_FRAMES_COUNT] = {0}; \
-		if (backtraces(frames, ARRAY_SIZE(frames))) \
-			store_message(type, (uintptr_t)ptr, fd, size, frames); \
-	}
 
 #endif

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -337,7 +337,7 @@ static void parse_ignore_backtraces()
 	char buf[64] = "";
 
 	if (!ignore_bts || !(len = strlen(ignore_bts))) {
-		debug("\n Ignore list empty\n");
+		debug("\n  Ignore list empty\n");
 		return;
 	}
 
@@ -363,11 +363,11 @@ static void parse_ignore_backtraces()
 		range = atoi(delim);
 
 		if (!frame) {
-			debug("\n Could not find dlsym() for '%s'", buf);
+			debug("\n  Could not find dlsym() for '%s'", buf);
 			continue;
 		}
 
-		debug("\n Ignoring '%s' frame 0x%08x range %u", buf, frame, range);
+		debug("\n  Ignoring '%s' frame 0x%08x range %u", buf, frame, range);
 		ignore_backtrace_push(frame, range);
 	}
 	debug("\n");

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -53,7 +53,7 @@ static void initialize_sock()
 		debug_exit("Could not open socket\n");
 
 	sock = getenv("SOCK");
-	if (!sock)
+	if (!sock || !strlen(sock))
 		sock = DEFAULT_SOCKET;
 	else if (strlen(sock) >= sizeof(sun.sun_path))
 		debug_exit("Sock path too long\n");
@@ -311,7 +311,7 @@ static const char *is_this_the_right_proc()
 	const char *proc_name = getenv("PROC");
 	const char *actual_proc_name = NULL;
 
-	if (!proc_name)
+	if (!proc_name || !strlen(proc_name))
 		debug_exit("No 'PROC' env var specified\n");
 
 	if (!(actual_proc_name = progname(pid)))
@@ -337,11 +337,10 @@ static void parse_ignore_backtraces()
 	/* no allocs, because "who knows ?" */
 	char buf[64] = "";
 
-	if (!ignore_bts) {
+	if (!ignore_bts || !(len = strlen(ignore_bts))) {
 		debug("\n Ignore list empty\n");
 		return;
 	}
-	len = strlen(ignore_bts);
 
 	lastp = endp = ignore_bts;
 	while (len > 0) {
@@ -411,7 +410,7 @@ static __attribute__((constructor(101))) void ocheck_init()
 	parse_ignore_backtraces();
 
 	/* if max_flush_counter <= 0 then flush only on ocheck_fini() */
-	if ((s = getenv("FLUSH_COUNT")))
+	if ((s = getenv("FLUSH_COUNT")) && strlen(s))
 		max_flush_counter = atoi(s);
 
 	flush_counter = max_flush_counter;

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -414,6 +414,9 @@ static __attribute__((constructor(101))) void ocheck_init()
 	if ((s = getenv("FLUSH_COUNT")))
 		max_flush_counter = atoi(s);
 
+	flush_counter = max_flush_counter;
+	debug("  Flush counter %u\n", flush_counter);
+
 	ocheck_init_store(get_alloc_msg_store());
 	ocheck_init_store(get_files_msg_store());
 

--- a/lib/ocheck.c
+++ b/lib/ocheck.c
@@ -16,8 +16,7 @@
 #include "ocheck.h"
 #include "ocheck-internal.h"
 
-#define DEFAULT_MAX_FLUSH_COUNTER	512
-static uint32_t max_flush_counter = DEFAULT_MAX_FLUSH_COUNTER;
+static uint32_t max_flush_counter = 0;
 static int fd = -1;
 static int flush_counter = -1;
 static pid_t pid = -1;


### PR DESCRIPTION
Optimizations:
* split the message stores into per-type ; so 1 message store for allocs & another one for FDs ; that gives a better feeling of limits of max allocs/FDs that would be used in an application (rather than when they were stored in a single place)
 * also added a upper limit index bound ; previously the code would iterate over the entire array to search for duplicate values ; as a note: duplicate values can exist if `realloc()` (or `calloc()`) calls `malloc()` ; so a pointer could appear twice in the table ; maybe a smarter hashing algorithm would be nicer (but I'll think about it later) ; if the program does not do too many allocs, the performance should be impacted too much
* disabled flushing messages during program execution (by default) ; this seems to impact performance quite a bit (since the flushing is blocking); to better optimize this, a bit more work is needed, but not sure if I'll keep this part (will think about it later)

Misc:
* added back fopen() & fclose() ; the assumption (I previously made) that this would be tracked by allocs was a bit wrong ; since this detail is strongly dependent on the implementation of the libc that's used
* fixed empty env vars ; we were checking for non-present env vars, not for empty env vars
* init & print `flush_counter` value on startup